### PR TITLE
Fix E565 error when s:callback() is called while textlock is active

### DIFF
--- a/autoload/notification.vim
+++ b/autoload/notification.vim
@@ -68,9 +68,8 @@ function! s:callback(timer) abort
       continue
     endif
 
-    let l:bufnr = winbufnr(l:winid)
     let l:lines = map(copy(l:context.lines), {i, v -> s:truncate(v, min([&columns - l:options.col, l:width]))})
-    call setbufline(l:bufnr, 1, l:lines)
+    call popup_settext(l:winid, l:lines)
     call popup_show(l:winid)
     call popup_setoptions(l:winid, l:options)
   endfor


### PR DESCRIPTION
Fix "E565: Not allowed to change text or change window" is given when `s:callback()` is called while textlock is active.

**Environment**

- Vim: 9.1.196
- Terminal: WezTerm
- OS: macOS 14 Sonoma


**Reproduce steps**

- Save this code to `vimrc.vim`

```vim
set nocompatible

" Please modify this path.
set runtimepath+=~/.cache/vim/pack/minpac/opt/vim-notification

function s:notify() abort
  call notification#show('hello world')
  return getchar()
endfunction

nnoremap <expr> @ <SID>notify()
```

- Launch Vim by `vim -u vimrc.vim`
- Type "@"
